### PR TITLE
improv: expose `ContextMenuItemBase`

### DIFF
--- a/desktop_context_menu/CHANGELOG.md
+++ b/desktop_context_menu/CHANGELOG.md
@@ -1,3 +1,7 @@
-# 0.1.0
+# 0.1.1
+
+* Expose `ContextMenuItemBase`.
+
+## 0.1.0
 
 * Initial release.

--- a/desktop_context_menu/example/pubspec.lock
+++ b/desktop_context_menu/example/pubspec.lock
@@ -56,28 +56,28 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.1"
   desktop_context_menu_macos:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       path: "../../desktop_context_menu_macos"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.1"
   desktop_context_menu_platform_interface:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       path: "../../desktop_context_menu_platform_interface"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.1"
   desktop_context_menu_windows:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       path: "../../desktop_context_menu_windows"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.1"
   effective_dart:
     dependency: transitive
     description:
@@ -207,4 +207,3 @@ packages:
     version: "2.1.1"
 sdks:
   dart: ">=2.14.0 <3.0.0"
-  flutter: ">=2.5.0"

--- a/desktop_context_menu/lib/desktop_context_menu.dart
+++ b/desktop_context_menu/lib/desktop_context_menu.dart
@@ -1,7 +1,7 @@
 import 'package:desktop_context_menu_platform_interface/desktop_context_menu_platform_interface.dart';
 
 export 'package:desktop_context_menu_platform_interface/desktop_context_menu_platform_interface.dart'
-    show ContextMenuItem, ContextMenuSeparator;
+    show ContextMenuItem, ContextMenuSeparator, ContextMenuItemBase;
 
 /// Exposes a simple API to show a context menu at the mouse coordinates.
 Future<ContextMenuItem?> showContextMenu({

--- a/desktop_context_menu/pubspec.yaml
+++ b/desktop_context_menu/pubspec.yaml
@@ -1,6 +1,6 @@
 name: desktop_context_menu
 description: A plugin that opens a context menu on the cursor position.
-version: 0.1.0
+version: 0.1.1
 repository: https://github.com/rows/desktop_context_menu/tree/main/desktop_context_menu
 homepage: https://github.com/rows/desktop_context_menu/tree/main/desktop_context_menu
 issue_tracker: https://github.com/rows/desktop_context_menu/issues
@@ -10,9 +10,9 @@ environment:
   flutter: ">=2.5.0"
 
 dependencies:
-  desktop_context_menu_platform_interface: ^0.1.0
-  desktop_context_menu_windows: ^0.1.0
-  desktop_context_menu_macos: ^0.1.0
+  desktop_context_menu_platform_interface: ^0.1.1
+  desktop_context_menu_windows: ^0.1.1
+  desktop_context_menu_macos: ^0.1.1
   flutter:
     sdk: flutter
 

--- a/desktop_context_menu_macos/CHANGELOG.md
+++ b/desktop_context_menu_macos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.1.1
 
-* Expose `ContextMenuItemBase`.
+* Update `desktop_context_menu` dependency.
 
 ## 0.1.0
 

--- a/desktop_context_menu_macos/CHANGELOG.md
+++ b/desktop_context_menu_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
-# 0.1.0
+# 0.1.1
+
+* Expose `ContextMenuItemBase`.
+
+## 0.1.0
 
 * Initial release.

--- a/desktop_context_menu_macos/pubspec.yaml
+++ b/desktop_context_menu_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: desktop_context_menu_macos
 description: The implementation of the context menu plugin for MacOS.
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/rows/desktop_context_menu/tree/main/desktop_context_menu_macos
 
 environment:
@@ -8,7 +8,7 @@ environment:
   flutter: ">=2.5.0"
 
 dependencies:
-  desktop_context_menu_platform_interface: ^0.1.0
+  desktop_context_menu_platform_interface: ^0.1.1
   flutter:
     sdk: flutter
 

--- a/desktop_context_menu_platform_interface/CHANGELOG.md
+++ b/desktop_context_menu_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.1.1
 
-* Expose `ContextMenuItemBase`.
+* Update `desktop_context_menu` dependency.
 
 ## 0.1.0
 

--- a/desktop_context_menu_platform_interface/CHANGELOG.md
+++ b/desktop_context_menu_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
-# 0.1.0
+# 0.1.1
+
+* Expose `ContextMenuItemBase`.
+
+## 0.1.0
 
 * Initial release.

--- a/desktop_context_menu_platform_interface/pubspec.yaml
+++ b/desktop_context_menu_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: desktop_context_menu_platform_interface
 description: A common platform interface for desktop_context_menu.
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/rows/desktop_context_menu/tree/main/desktop_context_menu_platform_interface
 
 environment:

--- a/desktop_context_menu_windows/CHANGELOG.md
+++ b/desktop_context_menu_windows/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.1.1
 
-* Expose `ContextMenuItemBase`.
+* Update `desktop_context_menu` dependency.
 
 ## 0.1.0
 

--- a/desktop_context_menu_windows/CHANGELOG.md
+++ b/desktop_context_menu_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
-# 0.1.0
+# 0.1.1
+
+* Expose `ContextMenuItemBase`.
+
+## 0.1.0
 
 * Initial release.

--- a/desktop_context_menu_windows/pubspec.yaml
+++ b/desktop_context_menu_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: desktop_context_menu_windows
 description: The implementation of the context menu plugin for Windows.
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/rows/desktop_context_menu/tree/main/desktop_context_menu_windows
 
 environment:
@@ -8,7 +8,7 @@ environment:
   flutter: ">=2.5.0"
 
 dependencies:
-  desktop_context_menu_platform_interface: ^0.1.0
+  desktop_context_menu_platform_interface: ^0.1.1
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
Expose `ContextMenuItemBase` so that the dev can pass a list of menu items through another widget for example.